### PR TITLE
Suggestion/Feature-Request: Add a MonadRec instance for LoggerT

### DIFF
--- a/src/Control/Monad/Logger/Trans.purs
+++ b/src/Control/Monad/Logger/Trans.purs
@@ -30,6 +30,10 @@ import Control.Monad.Reader.Trans
   , ask
   , local
   )
+import Control.Monad.Rec.Class
+  ( class MonadRec
+  , tailRecM
+  )
 import Control.Monad.Trans.Class (class MonadTrans, lift)
 import Data.Log.Message (Message)
 import Data.Newtype (class Newtype, unwrap)
@@ -79,6 +83,10 @@ instance monadAskLoggerT :: MonadAsk r m => MonadAsk r (LoggerT m) where
 
 instance monadReaderLoggerT :: MonadReader r m => MonadReader r (LoggerT m) where
   local = mapLoggerT <<< local
+
+instance monadRecLoggerT :: MonadRec m => MonadRec (LoggerT m) where
+  tailRecM step a =
+    LoggerT \l -> tailRecM (\a' -> unwrap (step a') l) a
 
 instance monadLoggerLoggerT :: MonadEffect m => MonadLogger (LoggerT m) where
   log message = LoggerT (_ $ message)


### PR DESCRIPTION
This allows you to use (e.g.) the [forever](https://pursuit.purescript.org/packages/purescript-tailrec/4.0.0/docs/Control.Monad.Rec.Class#v:forever) function with `LoggerT`